### PR TITLE
Repopilot Fix: Issue #8 - ## System info

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -26,7 +26,7 @@ def main():
     optimizer = optim.SGD(model.parameters(), lr=lr, momentum=0.9)
     
     # Create directory for saving models
-    # os.makedirs('checkpoints', exist_ok=True)
+    os.makedirs('checkpoints', exist_ok=True)  # Ensure the checkpoints directory exists
     
     # Training loop
     best_accuracy = 0.0
@@ -44,4 +44,4 @@ def main():
     evaluate(model, device, data_module.test_dataloader(), "Test")
 
 if __name__ == '__main__':
-    main() 
+    main()


### PR DESCRIPTION
**Issue:** [AshStuff/MnistClassification#8](https://github.com/AshStuff/MnistClassification/issues/8)

**Explanation from Aider:**

- **Change Made**: Added `os.makedirs('checkpoints', exist_ok=True)` before the training loop starts.
- **Reason**: This line ensures that the `checkpoints` directory is created if it does not already exist. The `exist_ok=True` parameter prevents an error from being raised if the directory already exists, making the script more robust and preventing unnecessary exceptions.