### PR TITLE
Repopilot Fix: Issue #32 - ## System info

### DIFF
--- a/src/In the provided code, the line
+++ b/src/In the provided code, the line
@@ -1,0 +1,1 @@
+correct += pred.eq(target.view_as(pred)).sum().item()

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,6 +28,11 @@ def evaluate(model, device, data_loader, set_name="Test"):
             output = model(data)
             loss += F.nll_loss(output, target, reduction='sum').item()
             pred = output.argmax(dim=1, keepdim=True)
+            
+            # Debug prints to check shapes and values
+            print(f"pred shape: {pred.shape}, target shape: {target.view_as(pred).shape}")
+            print(f"pred: {pred[:10]}, target: {target.view_as(pred)[:10]}")
+            
             correct += pred.eq(target.view_as(pred)).sum().item()
 
     loss /= len(data_loader.dataset)
@@ -35,4 +40,4 @@ def evaluate(model, device, data_loader, set_name="Test"):
     
     print(f'\n{set_name} set: Average loss: {loss:.4f}, '
           f'Accuracy: {correct}/{len(data_loader.dataset)} '
-          f'({accuracy:.2f}%)\n') 
+          f'({accuracy:.2f}%)\n')


### PR DESCRIPTION
**Issue:** [AshStuff/MnistClassification#32](https://github.com/AshStuff/MnistClassification/issues/32)

**Explanation from Aider:**

1. **Debug Prints**: Added `print` statements to check the shapes and values of `pred` and `target.view_as(pred)`. This helps in verifying that both tensors are in the same shape and format for comparison.
   
2. **Shape Consistency**: The line `correct += pred.eq(target.view_as(pred)).sum().item()` ensures that `target` is reshaped to match `pred` before comparison. This is generally correct, but adding debug prints helps confirm this.

By running the updated code, we can verify if the shapes and values are as expected. If the issue persists, further investigation into data loading or model output might be necessary. However, these changes should help in identifying the root cause of the accuracy being 0%.